### PR TITLE
Add Dependabot configuration with admin+devops labels

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "admin"
+      - "devops"
+    groups:
+      pip:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "admin"
+      - "devops"
+    groups:
+      actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary
- Add Dependabot configuration for automated dependency updates
- Configure pip ecosystem for Python dependency updates (requirements.txt)
- Configure github-actions ecosystem for workflow updates
- Use `admin` + `devops` labels instead of Dependabot defaults

## Test plan
- [ ] Verify Dependabot config syntax is valid
- [ ] After merge, trigger Dependabot or wait for next scheduled run
- [ ] Confirm new PRs have `admin` + `devops` labels