### PR TITLE
Fix fandanGO-aria integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+# Python
+__pycache__/
+*.py[cod]
+*.egg-info/
+
+# Local config (use config.yaml.template)
+config.yaml
+
+# IDE
+.vscode/
+.idea/

--- a/fandango_dls/actions/generate_metadata.py
+++ b/fandango_dls/actions/generate_metadata.py
@@ -91,6 +91,6 @@ def perform_action(args):
     Returns:
         dict: Results dictionary with success status and info
     """
-    success, info = generate_metadata_from_smartem(args['name'], args['acquisition-id'])
+    success, info = generate_metadata_from_smartem(args['name'], args['acquisition_id'])
     results = {'success': success, 'info': info}
     return results

--- a/fandango_dls/actions/send_metadata.py
+++ b/fandango_dls/actions/send_metadata.py
@@ -10,8 +10,7 @@ from fandango_dls.db.sqlite_db import get_project_metadata, get_project_data_loc
 
 # Import ARIA client from fandanGO-aria
 try:
-    from aria.client import AriaClient
-    from aria.data_manager import Bucket, Field
+    from fGOaria import AriaClient, Bucket, Field
 except ImportError:
     AriaClient = None
     print("Warning: fandanGO-aria not available. Install to enable ARIA integration.")
@@ -110,6 +109,6 @@ def perform_action(args):
     Returns:
         dict: Results dictionary with success status and info
     """
-    success, info = send_metadata_to_aria(args['name'], args['visit-id'])
+    success, info = send_metadata_to_aria(args['name'], args['visit_id'])
     results = {'success': success, 'info': info}
     return results


### PR DESCRIPTION
## Summary

- Fix argparse hyphen-to-underscore conversion for CLI arguments
- Fix fGOaria import path (was using incorrect `aria.client` module)
- Add `.gitignore` for Python artifacts and local config

## Details

The fandanGO-core CLI uses argparse which converts hyphenated arguments to underscores in the namespace. The action handlers were looking for the wrong keys:
- `args['acquisition-id']` → `args['acquisition_id']`
- `args['visit-id']` → `args['visit_id']`

The ARIA client import was also using the wrong module path (`aria.client` instead of `fGOaria`).

## Test plan

- [ ] Run `python -m core execute --action generate-metadata --name <project> --acquisition-id <uuid>`
- [ ] Run `python -m core execute --action send-metadata --name <project> --visit-id <id>`