### PR TITLE
fix: use // separator for nested Renovate preset path

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>DiamondLightSource/smartem-devtools:renovate/default"],
+  "extends": ["github>DiamondLightSource/smartem-devtools//renovate/default"],
   "packageRules": [
     {
       "description": "Group Python deps",


### PR DESCRIPTION
## Summary

Renovate's preset reference uses \`:\` for **sub-preset names** within a single file and \`//\` for **nested file paths**. The shared preset lives at \`renovate/default.json\` in smartem-devtools, so the correct reference is:

\`\`\`
github>DiamondLightSource/smartem-devtools//renovate/default
\`\`\`

The previous \`:\` form fails preset resolution (\"Preset name not found within published preset config\"), so Renovate cannot process this repo at all.

Same root cause and fix as DiamondLightSource/smartem-decisions#281, found while sweeping the org for the same misconfiguration.

## Test plan

- [x] \`renovate-config-validator --strict\` passes
- [ ] After merge, confirm Renovate runs cleanly on this repo