### PR TITLE
fix: bump requests minimum version to 2.33.0 to resolve GHSA-gc5v-m9x…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 fandanGO-core
 fandanGO-aria
 python-dotenv>=1.0.1
-requests>=2.32.4
+requests>=2.33.0
 tabulate>=0.9.0


### PR DESCRIPTION
…4-r6x2

Agent-Logs-Url: https://github.com/FragmentScreen/fandanGO-cryoem-dls/sessions/7b195c73-67d3-4b91-bee9-a1d019a55dcd