### PR TITLE
fix(deps): bump requests >=2.33.0 and python-dotenv >=1.2.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 fandanGO-core
 fandanGO-aria
-python-dotenv>=1.0.1
-requests>=2.32.4
+python-dotenv>=1.2.2
+requests>=2.33.0
 tabulate>=0.9.0


### PR DESCRIPTION
## Summary
Bumps minimum constraints in `requirements.txt` to clear two open code-scanning alerts:

| Alert | Package | From | To | CVE |
|-------|---------|------|----|----|
| [#5](https://github.com/DiamondLightSource/fandanGO-cryoem-dls/security/code-scanning/5) | requests | >=2.32.4 | >=2.33.0 | CVE-2026-25645 (GHSA-gc5v-m9x4-r6x2) |
| [#6](https://github.com/DiamondLightSource/fandanGO-cryoem-dls/security/code-scanning/6) | python-dotenv | >=1.0.1 | >=1.2.2 | CVE-2026-28684 (GHSA-mf9w-mj56-hr94) |

Both are direct dependencies. The change only bumps the minimum acceptable version so `pip install` resolves past the vulnerable range; no upper bound is introduced.

## Test plan
- [x] Both fix versions (`requests 2.33.0`, `python-dotenv 1.2.2`) are present on PyPI
- [ ] CI passes