### PR TITLE
Preserve ARIA API investigation and ADR-0015 fork-sync automation

### DIFF
--- a/.github/fandango-sync.yml
+++ b/.github/fandango-sync.yml
@@ -1,0 +1,38 @@
+# FandanGO Connector Sync Configuration
+# See: smartem-devtools/docs/decision-records/decisions/0015-facility-connector-fork-sync.md
+#
+# This file configures how changes from this facility-owned connector
+# are synced to the ARIA (FragmentScreen) fork for ecosystem visibility.
+
+sync:
+  # Enable or disable sync entirely
+  enabled: true
+
+  # Target fork repository
+  target:
+    org: FragmentScreen
+    repo: fandanGO-cryoem-dls
+
+  # Sync mode - choose one:
+  #   direct-push:   Push commits directly to fork (requires deploy key with write access)
+  #   per-commit-pr: Create a PR for each push (requires PAT with PR creation permissions)
+  #   buffered-pr:   Aggregate commits and create a single PR periodically (requires PAT)
+  mode: direct-push
+
+  # Branches to sync (currently only main is supported)
+  branches:
+    - main
+
+  # Buffer duration in hours for buffered-pr mode
+  # Ignored for other modes
+  buffer_hours: 24
+
+# Required secrets (configure in repository settings):
+#
+# For direct-push mode:
+#   ARIA_FORK_DEPLOY_KEY: SSH private key with write access to the fork
+#                         (ARIA adds the public key as a deploy key to their fork)
+#
+# For per-commit-pr or buffered-pr modes:
+#   ARIA_FORK_PAT: Personal access token with repo scope
+#                  (or fine-grained token with Contents and Pull Requests permissions)

--- a/.github/workflows/sync-to-aria.yml
+++ b/.github/workflows/sync-to-aria.yml
@@ -1,0 +1,280 @@
+# Sync facility connector to ARIA fork
+# See: smartem-devtools/docs/decision-records/decisions/0015-facility-connector-fork-sync.md
+#
+# This workflow syncs changes from the facility-owned repo to the ARIA fork.
+# Three modes are supported (configured in .github/fandango-sync.yml):
+#   - direct-push: Push commits directly to fork (requires deploy key)
+#   - per-commit-pr: Create a PR for each push
+#   - buffered-pr: Aggregate commits and create a single PR periodically
+
+name: Sync to ARIA Fork
+
+on:
+  push:
+    branches:
+      - main
+  schedule:
+    # Run daily at 06:00 UTC for buffered-pr mode
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+    inputs:
+      force_sync:
+        description: 'Force sync even if already in sync'
+        required: false
+        default: 'false'
+        type: boolean
+
+permissions:
+  contents: read
+
+jobs:
+  read-config:
+    runs-on: ubuntu-latest
+    outputs:
+      enabled: ${{ steps.config.outputs.enabled }}
+      mode: ${{ steps.config.outputs.mode }}
+      target_org: ${{ steps.config.outputs.target_org }}
+      target_repo: ${{ steps.config.outputs.target_repo }}
+      buffer_hours: ${{ steps.config.outputs.buffer_hours }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Read sync configuration
+        id: config
+        run: |
+          CONFIG_FILE=".github/fandango-sync.yml"
+          if [ ! -f "$CONFIG_FILE" ]; then
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::No sync configuration found at $CONFIG_FILE"
+            exit 0
+          fi
+
+          # Parse YAML config using yq
+          ENABLED=$(yq -r '.sync.enabled // true' "$CONFIG_FILE")
+          MODE=$(yq -r '.sync.mode // "direct-push"' "$CONFIG_FILE")
+          TARGET_ORG=$(yq -r '.sync.target.org // ""' "$CONFIG_FILE")
+          TARGET_REPO=$(yq -r '.sync.target.repo // ""' "$CONFIG_FILE")
+          BUFFER_HOURS=$(yq -r '.sync.buffer_hours // 24' "$CONFIG_FILE")
+
+          echo "enabled=$ENABLED" >> "$GITHUB_OUTPUT"
+          echo "mode=$MODE" >> "$GITHUB_OUTPUT"
+          echo "target_org=$TARGET_ORG" >> "$GITHUB_OUTPUT"
+          echo "target_repo=$TARGET_REPO" >> "$GITHUB_OUTPUT"
+          echo "buffer_hours=$BUFFER_HOURS" >> "$GITHUB_OUTPUT"
+
+          echo "Configuration loaded:"
+          echo "  enabled: $ENABLED"
+          echo "  mode: $MODE"
+          echo "  target: $TARGET_ORG/$TARGET_REPO"
+          echo "  buffer_hours: $BUFFER_HOURS"
+
+  direct-push:
+    needs: read-config
+    if: |
+      needs.read-config.outputs.enabled == 'true' &&
+      needs.read-config.outputs.mode == 'direct-push' &&
+      github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Configure SSH
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.ARIA_FORK_DEPLOY_KEY }}" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          ssh-keyscan github.com >> ~/.ssh/known_hosts
+
+      - name: Push to ARIA fork
+        env:
+          TARGET_ORG: ${{ needs.read-config.outputs.target_org }}
+          TARGET_REPO: ${{ needs.read-config.outputs.target_repo }}
+          GIT_SSH_COMMAND: ssh -i ~/.ssh/deploy_key -o StrictHostKeyChecking=yes
+        run: |
+          FORK_URL="git@github.com:${TARGET_ORG}/${TARGET_REPO}.git"
+
+          # Add ARIA fork as remote
+          git remote add aria "$FORK_URL"
+
+          # Check if we're already in sync
+          git fetch aria main || {
+            echo "::warning::Could not fetch from ARIA fork. It may not exist yet."
+            exit 0
+          }
+
+          LOCAL_SHA=$(git rev-parse HEAD)
+          REMOTE_SHA=$(git rev-parse aria/main 2>/dev/null || echo "")
+
+          if [ "$LOCAL_SHA" = "$REMOTE_SHA" ] && [ "${{ inputs.force_sync }}" != "true" ]; then
+            echo "Already in sync (both at $LOCAL_SHA)"
+            exit 0
+          fi
+
+          # Push to fork
+          echo "Pushing $LOCAL_SHA to $FORK_URL"
+          git push aria HEAD:main || {
+            echo "::warning::Push failed. This may be a permissions issue or the fork is ahead."
+            exit 0
+          }
+
+          echo "Successfully synced to ARIA fork"
+
+  per-commit-pr:
+    needs: read-config
+    if: |
+      needs.read-config.outputs.enabled == 'true' &&
+      needs.read-config.outputs.mode == 'per-commit-pr' &&
+      github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Create PR to ARIA fork
+        env:
+          GH_TOKEN: ${{ secrets.ARIA_FORK_PAT }}
+          TARGET_ORG: ${{ needs.read-config.outputs.target_org }}
+          TARGET_REPO: ${{ needs.read-config.outputs.target_repo }}
+        run: |
+          COMMIT_SHA=$(git rev-parse --short HEAD)
+          COMMIT_MSG=$(git log -1 --pretty=%s)
+          BRANCH_NAME="sync/upstream-${COMMIT_SHA}"
+
+          # Check if PR already exists for this commit
+          EXISTING_PR=$(gh pr list \
+            --repo "${TARGET_ORG}/${TARGET_REPO}" \
+            --search "sync/upstream-${COMMIT_SHA}" \
+            --json number \
+            --jq '.[0].number // empty' 2>/dev/null || echo "")
+
+          if [ -n "$EXISTING_PR" ]; then
+            echo "PR #$EXISTING_PR already exists for this commit"
+            exit 0
+          fi
+
+          # Create PR body
+          PR_BODY=$(cat <<EOF
+          ## Upstream Sync
+
+          This PR syncs changes from the upstream facility repository.
+
+          **Source**: ${{ github.repository }}@${COMMIT_SHA}
+          **Commit**: ${COMMIT_MSG}
+
+          ---
+          *Automated by [sync-to-aria workflow](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})*
+          EOF
+          )
+
+          # Create the PR using the GitHub API
+          # Note: This requires the fork to allow PRs from upstream
+          gh pr create \
+            --repo "${TARGET_ORG}/${TARGET_REPO}" \
+            --title "sync: ${COMMIT_MSG}" \
+            --body "$PR_BODY" \
+            --head "${{ github.repository_owner }}:main" \
+            --base main || {
+              echo "::warning::Could not create PR. The fork may not allow PRs from upstream."
+              exit 0
+            }
+
+          echo "Successfully created PR to ARIA fork"
+
+  buffered-pr:
+    needs: read-config
+    if: |
+      needs.read-config.outputs.enabled == 'true' &&
+      needs.read-config.outputs.mode == 'buffered-pr' &&
+      (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check for changes and create buffered PR
+        env:
+          GH_TOKEN: ${{ secrets.ARIA_FORK_PAT }}
+          TARGET_ORG: ${{ needs.read-config.outputs.target_org }}
+          TARGET_REPO: ${{ needs.read-config.outputs.target_repo }}
+          BUFFER_HOURS: ${{ needs.read-config.outputs.buffer_hours }}
+        run: |
+          # Fetch the fork's main branch to compare
+          git remote add aria "https://github.com/${TARGET_ORG}/${TARGET_REPO}.git"
+          git fetch aria main || {
+            echo "::warning::Could not fetch from ARIA fork. It may not exist yet."
+            exit 0
+          }
+
+          LOCAL_SHA=$(git rev-parse HEAD)
+          REMOTE_SHA=$(git rev-parse aria/main 2>/dev/null || echo "")
+
+          if [ "$LOCAL_SHA" = "$REMOTE_SHA" ] && [ "${{ inputs.force_sync }}" != "true" ]; then
+            echo "Already in sync (both at $LOCAL_SHA)"
+            exit 0
+          fi
+
+          # Check for existing open PR
+          EXISTING_PR=$(gh pr list \
+            --repo "${TARGET_ORG}/${TARGET_REPO}" \
+            --search "sync: Buffered upstream changes" \
+            --state open \
+            --json number \
+            --jq '.[0].number // empty' 2>/dev/null || echo "")
+
+          if [ -n "$EXISTING_PR" ]; then
+            echo "Buffered PR #$EXISTING_PR already exists and is open"
+            exit 0
+          fi
+
+          # Get commit log since last sync
+          COMMITS=$(git log --oneline aria/main..HEAD 2>/dev/null || git log --oneline -20)
+          COMMIT_COUNT=$(echo "$COMMITS" | wc -l)
+          DATE=$(date -u +"%Y-%m-%d")
+
+          # Create PR body
+          PR_BODY=$(cat <<EOF
+          ## Buffered Upstream Sync
+
+          This PR syncs accumulated changes from the upstream facility repository.
+
+          **Source**: ${{ github.repository }}
+          **Date**: ${DATE}
+          **Commits**: ${COMMIT_COUNT}
+
+          ### Changes
+
+          \`\`\`
+          ${COMMITS}
+          \`\`\`
+
+          ---
+          *Automated by [sync-to-aria workflow](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})*
+          EOF
+          )
+
+          # Create the PR
+          gh pr create \
+            --repo "${TARGET_ORG}/${TARGET_REPO}" \
+            --title "sync: Buffered upstream changes (${DATE})" \
+            --body "$PR_BODY" \
+            --head "${{ github.repository_owner }}:main" \
+            --base main || {
+              echo "::warning::Could not create PR. The fork may not allow PRs from upstream."
+              exit 0
+            }
+
+          echo "Successfully created buffered PR to ARIA fork"
+
+  notify-failure:
+    needs: [read-config, direct-push, per-commit-pr, buffered-pr]
+    if: failure()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Log sync failure
+        run: |
+          echo "::warning::ARIA fork sync failed. Check the workflow logs for details."
+          echo "This is a warning, not an error - the build continues."

--- a/tests/api/FINDINGS.md
+++ b/tests/api/FINDINGS.md
@@ -1,0 +1,132 @@
+# ARIA API Test Findings
+
+**Date**: 2026-01-29
+**User**: val.redchenko@diamond.ac.uk (ID: 86)
+**Environment**: ARIA Beta
+
+## Summary
+
+Authentication is working correctly. The issues are server-side:
+- **Data-deposition API** returns **401 Unauthorized** even with proper entity filters
+- **Access/Permission APIs** return **500 Internal Server Error**
+- **Site queries** return **401 Unauthorized** (except `mySitesItems`)
+
+## Test Results
+
+| Test | Endpoint | Result | Notes |
+|------|----------|--------|-------|
+| Introspection | graphql-beta | SUCCESS | Schema access works |
+| User Info | graphql-beta | SUCCESS | User recognised, ID=86 |
+| **My Sites** | **graphql-beta** | **SUCCESS** | **User has joined 1 site** |
+| Sites List | graphql-beta | 401 Error | Cannot list all sites |
+| Site Membership | graphql-beta | 500 Error | Server-side issue |
+| Facilities | structuralbiology.eu | 500 Error | Server-side issue |
+| Visit by ID | structuralbiology.eu | 500 Error | Server-side issue |
+| Visit Permissions | structuralbiology.eu | 500 Error | Server-side issue |
+| **Buckets (with filters)** | **datadeposition.beta** | **401 Unauthorized** | **Key finding** |
+
+## Key Finding: Sites vs Visits Are Separate Concepts
+
+**Sites and visits are separate concepts in ARIA:**
+- **Sites** = user membership, GDPR consent, access routes (like "beta" vs "production")
+- **Visits** = scientific visits to facilities, linked to proposals/access/calls
+
+### Bucket Query Filters
+
+When querying buckets, we provide:
+- `aria_id` = visit ID (e.g., 2842)
+- `aria_entity_type` = "visit"
+
+**No site_id is provided** - `BucketFilters` doesn't have a site filter:
+```
+BucketFilters: id, aria_id, aria_entity_type, owner, embargoed_until, created, updated
+```
+
+### Visit Query Filters
+
+`VisitFilters` also has **no site_id filter**:
+```
+VisitFilters: plid, status, order, confirmed, completed, cancelled, detail,
+              tech_eval_positive, suspension_count, cid, access_id, proposal_id, call_id, id
+```
+
+**We cannot list visits per site** - there's no site filter, and `visitItems` returns 500 anyway.
+
+## Key Finding: Site Membership
+
+The user has joined one site:
+```json
+{
+  "mySitesItems": [
+    {
+      "id": "15b465be-b577-4310-aea9-6c1476b19f2d",
+      "username": "47f4d43c-d757-4d5c-b5f7-33fa20a43caa",
+      "site_id": "4980de81-ccdd-492b-b510-ae18ffc173d9",
+      "created": "2026-01-19 14:06:34"
+    }
+  ]
+}
+```
+
+However:
+- **Cannot query site details** (siteItem returns 401)
+- **Cannot list all sites** (siteItems returns 401)
+- **Cannot check membership status** (isMemberItems returns 500)
+
+This confirms:
+1. **Site membership exists** - the user joined a site on 2026-01-19
+2. **Missing site membership is NOT the root cause** - the 401 persists despite site membership
+3. The issue is server-side permission handling in the data-deposition API
+
+## Bucket Query Issue
+
+The bucket query returns 401 **even when using the same filter pattern as fandanGO-aria**:
+
+```graphql
+query($filters: BucketFilters) {
+  bucketItems(filters: $filters) {
+    id aria_id aria_entity_type owner created
+  }
+}
+
+# Variables:
+{"filters": {"aria_id": 2842, "aria_entity_type": "visit"}}
+```
+
+Error response:
+```
+FAEResolver: Status 401 - Unauthorized from
+https://datadeposition.beta.api.aria.services/api/v1/bucket?_sort=order&_order=asc&length=0&filter[aria_id]=2842&filter[aria_entity_type]=visit
+```
+
+## Hypotheses Tested
+
+| Hypothesis | Status | Evidence |
+|------------|--------|----------|
+| Missing filters cause 401 | Disproved | 401 persists with proper entity scoping |
+| Missing site membership | Disproved | User has joined a site (mySitesItems) |
+| Wrong site membership | Unknown | Cannot query site details (siteItem returns 401) |
+| Server-side permission bug | **Likely** | Multiple APIs returning 401/500 |
+
+## Next Steps
+
+1. Keep the GitHub issue open - this is a legitimate ARIA bug
+2. The ARIA team needs to investigate:
+   - Why the data-deposition API returns 401 for a user with facility admin permissions
+   - Why the access/permission APIs return 500 errors
+   - Why siteItem/siteItems return 401 even for a user's own site
+3. Ask ARIA team about site `4980de81-ccdd-492b-b510-ae18ffc173d9` - what site is this?
+4. Test again after ARIA team responds
+
+## Affected APIs
+
+| API | Base URL | Issue |
+|-----|----------|-------|
+| Data Deposition | datadeposition.beta.api.aria.services | 401 on bucket queries |
+| Pages (Sites) | pages.beta.api.aria.services | 401 on site queries |
+| Profile | profile.beta.api.aria.services | 500 on membership queries |
+| Access | beta.structuralbiology.eu | 500 on visit/facility queries |
+| Permissions | beta.structuralbiology.eu | 500 on permission queries |
+| User | (works) | No issues |
+| My Sites | (works) | No issues |
+| GraphQL Schema | graphql-beta.aria.services | No issues |

--- a/tests/api/README.md
+++ b/tests/api/README.md
@@ -1,0 +1,75 @@
+# ARIA API Verification Tests
+
+Manual verification tests for ARIA GraphQL API connectivity and permissions.
+These tests help diagnose authentication and authorisation issues with the ARIA beta environment.
+
+## Status: not currently runnable
+
+These scripts call a GraphQL runner (`node run.js`) that lived outside this repository, in a personal
+workspace at `$ERIC_ROOT/.claude/skills/graphql`. That runner no longer exists - only its
+`node_modules` directory survives - so `run_query` in `common.sh` will fail.
+
+They are committed as the record of the ARIA API investigation rather than as an executable suite: the
+GraphQL queries, variables and endpoints in each script are exactly what was sent, and `FINDINGS.md`
+records what came back. Reviving them means supplying any GraphQL client that can post an authenticated
+query, and repointing `run_query`.
+
+## Prerequisites
+
+1. ARIA credentials configured in `$ERIC_ROOT/tmp/aria-beta.env`
+2. A GraphQL runner at `$ERIC_ROOT/.claude/skills/graphql` exposing `run.js` (see Status above)
+3. Node.js installed
+
+## Environment Setup
+
+The tests expect `ERIC_ROOT` to point to the workspace root, or will auto-detect if run from within the workspace.
+
+```bash
+export ERIC_ROOT=/home/vredchenko/dev/ERIC
+```
+
+## Running Tests
+
+Run all tests:
+```bash
+./run_all.sh
+```
+
+Run individual tests:
+```bash
+./test_buckets_with_filters.sh
+./test_facilities.sh
+./test_introspection.sh
+./test_visit_permissions.sh
+./test_create_bucket.sh
+```
+
+## Test Descriptions
+
+| Test | Purpose |
+|------|---------|
+| `test_introspection.sh` | Schema introspection - verifies basic GraphQL connectivity |
+| `test_user_info.sh` | Query current user - verifies token is valid and user recognised |
+| `test_facilities.sh` | Query facilities - verifies read access to facility data |
+| `test_visit_by_id.sh` | Query visit by ID - verifies visit data access |
+| `test_buckets_with_filters.sh` | Query buckets with entity filters - tests permission scoping |
+| `test_visit_permissions.sh` | Query visit permissions - verifies permission API access |
+| `test_create_bucket.sh` | Create a bucket - tests write permissions (run after reads work) |
+
+## Known Visit IDs for Testing
+
+From ARIA dev team - user has admin permissions for DLS facility:
+- Visit 2842
+- Visit 2460
+- Visit 2106
+
+## Interpreting Results
+
+- **401 Unauthorized**: Permission check failed - see investigation notes
+- **500 Internal Server Error**: Server-side issue - escalate to ARIA team
+- **Empty array `[]`**: Query succeeded, no data exists (expected for new visits)
+- **Data returned**: Full success
+
+## Findings
+
+See `FINDINGS.md` for detailed test results and analysis from 2026-01-29.

--- a/tests/api/common.sh
+++ b/tests/api/common.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# Common setup for ARIA API tests
+
+# Auto-detect ERIC_ROOT if not set
+if [[ -z "$ERIC_ROOT" ]]; then
+    # Walk up from script location to find workspace root
+    # Path: repos/DiamondLightSource/fandanGO-cryoem-dls/tests/api -> ERIC (5 levels)
+    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    ERIC_ROOT="$(cd "$SCRIPT_DIR/../../../../.." && pwd)"
+fi
+
+GRAPHQL_SKILL_DIR="$ERIC_ROOT/.claude/skills/graphql"
+ENV_FILE="$ERIC_ROOT/tmp/aria-beta.env"
+
+# Validate prerequisites
+check_prerequisites() {
+    if [[ ! -f "$ENV_FILE" ]]; then
+        echo "ERROR: Environment file not found: $ENV_FILE"
+        echo "Create it with ARIA_CONNECTION_USERNAME and ARIA_CONNECTION_PASSWORD"
+        exit 1
+    fi
+
+    if [[ ! -d "$GRAPHQL_SKILL_DIR" ]]; then
+        echo "ERROR: GraphQL skill not found: $GRAPHQL_SKILL_DIR"
+        exit 1
+    fi
+
+    if ! command -v node &> /dev/null; then
+        echo "ERROR: Node.js not found"
+        exit 1
+    fi
+}
+
+# Load environment and export for GraphQL skill
+load_env() {
+    source "$ENV_FILE"
+    export ARIA_USERNAME="$ARIA_CONNECTION_USERNAME"
+    export ARIA_PASSWORD="$ARIA_CONNECTION_PASSWORD"
+}
+
+# Run a GraphQL query
+# Usage: run_query "query" [--variables '{"key": "value"}'] [--endpoint name]
+run_query() {
+    local query="$1"
+    shift
+
+    cd "$GRAPHQL_SKILL_DIR"
+    node run.js "$query" "$@"
+}
+
+# Default test visit IDs (user has admin permissions for DLS)
+TEST_VISIT_ID="${TEST_VISIT_ID:-2842}"
+TEST_VISIT_ID_ALT1="${TEST_VISIT_ID_ALT1:-2460}"
+TEST_VISIT_ID_ALT2="${TEST_VISIT_ID_ALT2:-2106}"

--- a/tests/api/run_all.sh
+++ b/tests/api/run_all.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+# Run all ARIA API verification tests
+# Stops on first failure unless --continue flag is passed
+
+set -e
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+CONTINUE_ON_FAILURE=false
+SKIP_WRITE_TESTS=true
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --continue)
+            CONTINUE_ON_FAILURE=true
+            shift
+            ;;
+        --include-writes)
+            SKIP_WRITE_TESTS=false
+            shift
+            ;;
+        *)
+            echo "Unknown option: $1"
+            echo "Usage: $0 [--continue] [--include-writes]"
+            exit 1
+            ;;
+    esac
+done
+
+echo "========================================"
+echo "ARIA API Verification Tests"
+echo "========================================"
+echo
+echo "Options:"
+echo "  Continue on failure: $CONTINUE_ON_FAILURE"
+echo "  Skip write tests: $SKIP_WRITE_TESTS"
+echo
+
+run_test() {
+    local test_script="$1"
+    local test_name=$(basename "$test_script" .sh)
+
+    echo
+    echo "----------------------------------------"
+    echo "Running: $test_name"
+    echo "----------------------------------------"
+
+    if $CONTINUE_ON_FAILURE; then
+        "$test_script" || echo "FAILED: $test_name"
+    else
+        "$test_script"
+    fi
+}
+
+# Read-only tests (safe to run)
+run_test "$SCRIPT_DIR/test_introspection.sh"
+run_test "$SCRIPT_DIR/test_user_info.sh"
+run_test "$SCRIPT_DIR/test_sites_list.sh"
+run_test "$SCRIPT_DIR/test_my_sites.sh"
+run_test "$SCRIPT_DIR/test_site_membership.sh"
+run_test "$SCRIPT_DIR/test_facilities.sh"
+run_test "$SCRIPT_DIR/test_visit_by_id.sh"
+run_test "$SCRIPT_DIR/test_buckets_with_filters.sh"
+run_test "$SCRIPT_DIR/test_visit_permissions.sh"
+
+# Write tests (create real data)
+if ! $SKIP_WRITE_TESTS; then
+    echo
+    echo "========================================"
+    echo "Write Tests (creates real data)"
+    echo "========================================"
+    run_test "$SCRIPT_DIR/test_create_bucket.sh"
+else
+    echo
+    echo "========================================"
+    echo "Skipping write tests (use --include-writes to enable)"
+    echo "========================================"
+fi
+
+echo
+echo "========================================"
+echo "All tests completed"
+echo "========================================"

--- a/tests/api/test_buckets_with_filters.sh
+++ b/tests/api/test_buckets_with_filters.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Test: Query buckets WITH entity filters
+# Purpose: Test if 401 error is caused by missing filters
+#
+# Background: fandanGO-aria always queries buckets with aria_id and aria_entity_type filters.
+# The ARIA permission system checks canView() for each bucket, which requires entity scope.
+# Unfiltered queries may fail because permission checks cannot be performed system-wide.
+#
+# Expected: Returns buckets for the visit (or empty array if none exist)
+# If 401: Issue is NOT missing filters - escalate to ARIA team
+
+set -e
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/common.sh"
+
+echo "=== Test: Query Buckets with Filters ==="
+echo "Purpose: Test if 401 error is caused by missing entity filters"
+echo "Visit ID: $TEST_VISIT_ID"
+echo
+
+check_prerequisites
+load_env
+
+QUERY='query($filters: BucketFilters) { bucketItems(filters: $filters) { id aria_id aria_entity_type owner created } }'
+VARIABLES="{\"filters\": {\"aria_id\": $TEST_VISIT_ID, \"aria_entity_type\": \"visit\"}}"
+
+echo "Query: $QUERY"
+echo "Variables: $VARIABLES"
+echo
+
+run_query "$QUERY" --variables "$VARIABLES" --endpoint beta
+
+echo
+echo "Expected: Array of buckets (possibly empty) OR 401 if server-side issue"

--- a/tests/api/test_create_bucket.sh
+++ b/tests/api/test_create_bucket.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Test: Create a bucket
+# Purpose: Verify write permissions after reads work
+#
+# WARNING: This creates real data in the ARIA beta environment.
+# Only run after read tests succeed.
+#
+# Expected: Returns created bucket with id
+# If 401: User lacks write permissions for this visit
+
+set -e
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/common.sh"
+
+echo "=== Test: Create Bucket ==="
+echo "Purpose: Verify write permissions"
+echo "Visit ID: $TEST_VISIT_ID"
+echo
+echo "WARNING: This creates real data in ARIA beta environment"
+echo
+
+check_prerequisites
+load_env
+
+# Embargo date 1 year from now
+EMBARGO_DATE=$(date -d "+1 year" +%Y-%m-%dT00:00:00Z 2>/dev/null || date -v+1y +%Y-%m-%dT00:00:00Z)
+
+QUERY='mutation($input: CreateBucketInput!) { createDataBucket(input: $input) { id aria_id aria_entity_type owner created } }'
+VARIABLES="{\"input\": {\"aria_id\": $TEST_VISIT_ID, \"aria_entity_type\": \"visit\", \"embargoed_until\": \"$EMBARGO_DATE\"}}"
+
+echo "Query: $QUERY"
+echo "Variables: $VARIABLES"
+echo
+
+run_query "$QUERY" --variables "$VARIABLES" --endpoint beta
+
+echo
+echo "Expected: Created bucket object with id, aria_id, aria_entity_type"

--- a/tests/api/test_facilities.sh
+++ b/tests/api/test_facilities.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Test: Query facilities
+# Purpose: Verify read access to facility data (should include DLS)
+#
+# Expected: Returns list of facilities including Diamond Light Source
+# If 401: User lacks facility read permissions
+
+set -e
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/common.sh"
+
+echo "=== Test: Query Facilities ==="
+echo "Purpose: Verify read access to facility data"
+echo
+
+check_prerequisites
+load_env
+
+echo "Querying all facilities..."
+echo
+
+run_query '{ facilityItems { id name } }' --endpoint beta
+
+echo
+echo "Expected: List should include Diamond Light Source (DLS)"

--- a/tests/api/test_introspection.sh
+++ b/tests/api/test_introspection.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Test: Schema introspection
+# Purpose: Verify basic GraphQL connectivity and discover available queries
+#
+# Expected: Returns list of query field names
+# If 401: Authentication completely broken
+
+set -e
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/common.sh"
+
+echo "=== Test: Schema Introspection ==="
+echo "Purpose: Verify basic GraphQL connectivity"
+echo
+
+check_prerequisites
+load_env
+
+echo "Querying schema for available query types..."
+echo
+
+run_query '{ __schema { queryType { fields { name } } } }' --endpoint beta
+
+echo
+echo "Look for: bucketItems, facilityItems, visitPermissionItems, proposalPermissionItems"

--- a/tests/api/test_my_sites.sh
+++ b/tests/api/test_my_sites.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Test: Query sites the current user has joined
+# Purpose: Check if user has joined any sites (required for access)
+#
+# Expected: List of sites user has joined
+# If empty: User needs to join a site via ARIA web UI (GDPR consent)
+# If 401/403: Site membership may be required for API access
+
+set -e
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/common.sh"
+
+echo "=== Test: Query My Sites ==="
+echo "Purpose: Check which sites the user has joined"
+echo
+echo "From ARIA Access Glossary:"
+echo "  - Users must 'join' a site by logging in and consenting to GDPR data processing"
+echo "  - Sites segregate users, access routes, facilities, and content"
+echo "  - Site membership may be required for API access"
+echo
+
+check_prerequisites
+load_env
+
+echo "Querying mySitesItems..."
+echo
+
+run_query '{ mySitesItems { id username site_id created } }' --endpoint beta
+
+echo
+echo "Expected: List of sites the user has joined (site_id is a UUID)"
+echo "If empty: User may need to join a site via ARIA web UI"
+echo

--- a/tests/api/test_site_membership.sh
+++ b/tests/api/test_site_membership.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# Test: Check site membership status
+# Purpose: Verify if user is a member of specific sites
+#
+# Expected: Boolean membership status
+# If false: User needs to join the site
+# Note: These queries return 500 on beta - server-side issue
+
+set -e
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/common.sh"
+
+echo "=== Test: Check Site Membership ==="
+echo "Purpose: Verify membership status for specific sites"
+echo
+echo "Note: These queries currently return 500 on beta environment."
+echo "      This appears to be a server-side issue in the profile API."
+echo
+
+check_prerequisites
+load_env
+
+echo "Querying isMemberItems..."
+echo "Note: This checks if the current user is a member of any site"
+echo
+
+run_query '{ isMemberItems { username site_id is_member } }' --endpoint beta || true
+
+echo
+echo "Expected: Membership records for the current user"
+echo "If empty: User may not be a member of any site"
+echo
+
+# Also try querying siteMembersItems to see if we can view membership lists
+echo "---"
+echo
+echo "Querying siteMembersItems (may require admin permissions)..."
+echo
+
+run_query '{ siteMembersItems { id username site_id email first_name last_name } }' --endpoint beta || true
+
+echo
+echo "Expected: List of site members (or 500 error - server-side issue)"
+echo

--- a/tests/api/test_sites_list.sh
+++ b/tests/api/test_sites_list.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Test: List all available sites
+# Purpose: See what sites exist that the user could join
+#
+# Expected: List of all ARIA sites
+# Useful for: Identifying which site(s) the user should join
+# Note: This query returns 401 on beta - site list may require admin permissions
+
+set -e
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/common.sh"
+
+echo "=== Test: List All Sites ==="
+echo "Purpose: See what sites are available to join"
+echo
+echo "Note: This query often returns 401 on beta environment."
+echo "      Site listing may require admin permissions."
+echo
+
+check_prerequisites
+load_env
+
+echo "Querying siteItems..."
+echo
+
+run_query '{ siteItems { id name title home_uri perm_attribute active is_admin } }' --endpoint beta || true
+
+echo
+echo "Expected: List of all available sites (or 401 if restricted)"
+echo "Look for: DLS-related sites or beta/test sites"
+echo "Note: is_admin indicates if current user is admin for that site"
+echo

--- a/tests/api/test_user_info.sh
+++ b/tests/api/test_user_info.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Test: Query current user info
+# Purpose: Verify token is valid and user is recognized by ARIA
+#
+# Expected: Returns current user details
+# If fails: Token/authentication issues
+
+set -e
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/common.sh"
+
+echo "=== Test: Query Current User Info ==="
+echo "Purpose: Verify token is valid and user is recognized"
+echo
+
+check_prerequisites
+load_env
+
+# Try userItem query
+echo "Querying user info..."
+echo
+
+run_query '{ userItems { id username email } }' --endpoint beta
+
+echo
+echo "Expected: Current user details (id, username, email)"

--- a/tests/api/test_visit_by_id.sh
+++ b/tests/api/test_visit_by_id.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Test: Query visit by ID
+# Purpose: Verify we can read visit data directly (not through bucket/permission APIs)
+#
+# Expected: Returns visit details for the specified ID
+# If 401/500: General API access issues
+
+set -e
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/common.sh"
+
+echo "=== Test: Query Visit by ID ==="
+echo "Purpose: Verify we can read visit data directly"
+echo "Visit ID: $TEST_VISIT_ID"
+echo
+
+check_prerequisites
+load_env
+
+QUERY='query($filters: VisitFilters) { visitItems(filters: $filters) { id proposal_id status confirmed completed } }'
+VARIABLES="{\"filters\": {\"id\": $TEST_VISIT_ID}}"
+
+echo "Query: $QUERY"
+echo "Variables: $VARIABLES"
+echo
+
+run_query "$QUERY" --variables "$VARIABLES" --endpoint beta
+
+echo
+echo "Expected: Visit details for ID $TEST_VISIT_ID"

--- a/tests/api/test_visit_permissions.sh
+++ b/tests/api/test_visit_permissions.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Test: Query visit permissions
+# Purpose: Verify user has expected permissions for test visit
+#
+# Expected: Returns permission scopes for the visit
+# If 401: User lacks permission API access
+
+set -e
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/common.sh"
+
+echo "=== Test: Query Visit Permissions ==="
+echo "Purpose: Verify user permissions for test visit"
+echo "Visit ID: $TEST_VISIT_ID"
+echo
+
+check_prerequisites
+load_env
+
+QUERY='query($filters: VisitPermissionFilters) { visitPermissionItems(filters: $filters) { entity_id scopes } }'
+VARIABLES="{\"filters\": {\"entity_id\": $TEST_VISIT_ID}}"
+
+echo "Query: $QUERY"
+echo "Variables: $VARIABLES"
+echo
+
+run_query "$QUERY" --variables "$VARIABLES" --endpoint beta
+
+echo
+echo "Expected: Permission scopes for visit $TEST_VISIT_ID"


### PR DESCRIPTION
Both commits are work that existed only as untracked files on a single laptop. Committing them is a
handover measure: the laptop is being reclaimed at the end of the contract.

## `test:` ARIA API verification probes and findings

Fourteen files under `tests/api/` - a set of GraphQL probes against the ARIA beta environment, plus
`FINDINGS.md` recording the 2026-01-29 run.

The substance of `FINDINGS.md`: **deposition to ARIA has never worked end to end.** Authentication is
fine and the user is recognised, but the data-deposition API returns **401** on bucket queries and the
access/permission APIs return **500**. Two hypotheses were tested and disproved - missing entity
filters, and missing site membership (the user has joined a site since 2026-01-19). The remaining
explanation is a server-side permission problem in ARIA, which needs escalating to the ARIA team.

### These scripts do not currently run

`common.sh` calls `node run.js` in a GraphQL runner at `$ERIC_ROOT/.claude/skills/graphql`, which lived
outside this repository in a personal workspace. That runner no longer exists - only its `node_modules`
directory remains - so `run_query` fails. The same is true of the copy under `smartem-devtools`, which
was never committed either.

They are therefore committed as the record of the investigation, not as an executable suite. Each
script contains the exact query, variables and endpoint that were sent, and `FINDINGS.md` has the
responses, so the work is reproducible with any authenticated GraphQL client. A "Status" section at the
top of `tests/api/README.md` says so, to save the next person the discovery.

## `ci:` ADR-0015 fork-sync workflow and configuration

`.github/workflows/sync-to-aria.yml` and `.github/fandango-sync.yml` implement the mirror described in
[ADR 0015](https://github.com/DiamondLightSource/smartem-devtools/blob/main/docs/decision-records/decisions/0015-facility-connector-fork-sync.md):
this repository is authoritative, the FragmentScreen copy is downstream. Three modes are supported -
`direct-push`, `per-commit-pr`, `buffered-pr` - selected in the config file, currently `direct-push`.

**It is inert on merge.** `direct-push` needs an `ARIA_FORK_DEPLOY_KEY` secret; the only secret set on
this repository is `RENOVATE_TOKEN`. Every step that touches the fork is written to warn and `exit 0`,
so the workflow will run on each push to `main` and do nothing.

**Note for whoever inherits this:** `sync.enabled` is left at `true` deliberately, per the ADR. That
means adding the `ARIA_FORK_DEPLOY_KEY` secret is on its own enough to start pushing this repository's
`main` to `FragmentScreen/fandanGO-cryoem-dls` - no code change required. Set `sync.enabled: false` if
you would rather that be a deliberate two-step decision.

## Checks

`gitleaks` clean across all 42 commits. No credentials in either commit - `common.sh` sources them from
a file outside the repository. `FINDINGS.md` does contain the author's work email, ARIA user ID and the
site/membership UUIDs from their own record, which is what makes the 401 analysis legible.
